### PR TITLE
Make the sync system cloud specific

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.include) }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,8 +26,7 @@ jobs:
         id: process_cloud_choice
         run: |
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            JSON="{ \"selected_clouds\" : [ \"aws\" ] }"
-            echo "clouds=$JSON" >> $GITHUB_OUTPUT
+            echo "clouds={ \"selected_clouds\" : [ \"aws\" ] }" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
             JSON="{ \"selected_clouds\" : [ \"azure\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -55,16 +55,19 @@ jobs:
               echo "JSON_ARRAY=$jsonArrayString" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
           esac
 
+      - name: Show JASON
+        run: |
+          echo "${{ fromJSON(JSON_ARRAY) }}"
 
       # - name: Set matrix based on cloud-id
       #   id: matrix

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -56,18 +56,23 @@ jobs:
                 { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
                 { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' }
               ]" >> $GITHUB_ENV
+              ;;
             aws)
               echo "modules=[
                 { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
               ]" >> $GITHUB_ENV
+              ;;
             azure)
               echo "modules=[
                 { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
               ]" >> $GITHUB_ENV
+              ;;
             gcp)
               echo "modules=[
                 { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' },
               ]" >> $GITHUB_ENV
+              ;;
+          esac
 
 
       # - name: Set matrix based on cloud-id

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -80,11 +80,11 @@ jobs:
       - name: Set repo env
         run: |
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
-              echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+              echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_ENV
           elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
-              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_ENV
           elif [[ "${{ matrix.cloudid }}" == "azure" ]]; then
-              echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+              echo "repo=terraform-google-vmseries-modules" >> $GITHUB_ENV
           fi
 
           echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,16 +51,16 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
           case "${{ inputs.cloud-id }}" in
             all)
-              echo "modules=[ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ]" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules=[ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ]" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules=[ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ]" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules=[ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ]" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
           esac
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -20,6 +20,8 @@ jobs:
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
+    env:
+      clouds: ''
     outputs:
       clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
     steps:
@@ -36,28 +38,17 @@ jobs:
             echo "clouds=['gcp']" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
             echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
-          fi          
+          fi
 
-        #   case "${{ inputs.cloud-id }}" in
-        #     all)
-        #       echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
-        #       ;;
-        #     aws)
-        #       echo "clouds=['aws']" >> $GITHUB_ENV
-        #       ;;
-        #     azure)
-        #       echo "clouds=['azure']" >> $GITHUB_ENV
-        #       ;;
-        #     gcp)
-        #       echo "clouds=['gcp']" >> $GITHUB_ENV
-        #       ;;
-        #   esac    
+          echo "${{ env.clouds }}"
+
       - name: Show CLOUDS
         run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
+    needs: generate-matrix
     env:
       repo: ''
     strategy:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -134,8 +134,11 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        ${{ fromJSON(needs.generate-matrix.outputs.modules) }}
+      # HERE
+      # matrix:
+      #   ${{ fromJSON(needs.generate-matrix.outputs.modules) }}
+
+
 
         # include:
         #   # AWS
@@ -209,6 +212,11 @@ jobs:
 
 
     steps:
+      
+      - name: Show modules
+        run: |
+          echo "${{ fromJSON(needs.generate-matrix.outputs.modules) }}"
+
       - name: Show input cloud-id
         run: |
           echo "${{ inputs.cloud-id }}"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,30 +49,57 @@ jobs:
         id: set_modules
         run: |
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-          case "${{ inputs.cloud-id }}" in
+            case "${{ inputs.cloud-id }}" in
             all)
-              echo "modules=[
-                { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
-                { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
-                { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' }
-              ]" >> $GITHUB_ENV
+              echo "modules=\"[
+                { \\\"cloudid\\\": \\\"aws\\\", \\\"repo\\\": \\\"terraform-aws-vmseries-modules\\\" },
+                { \\\"cloudid\\\": \\\"azure\\\", \\\"repo\\\": \\\"terraform-azurerm-vmseries-modules\\\" },
+                { \\\"cloudid\\\": \\\"gcp\\\", \\\"repo\\\": \\\"terraform-google-vmseries-modules\\\" }
+              ]\"" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules=[
-                { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
-              ]" >> $GITHUB_ENV
+              echo "modules=\"[
+                { \\\"cloudid\\\": \\\"aws\\\", \\\"repo\\\": \\\"terraform-aws-vmseries-modules\\\" }
+              ]\"" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules=[
-                { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
-              ]" >> $GITHUB_ENV
+              echo "modules=\"[
+                { \\\"cloudid\\\": \\\"azure\\\", \\\"repo\\\": \\\"terraform-azurerm-vmseries-modules\\\" }
+              ]\"" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules=[
-                { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' },
-              ]" >> $GITHUB_ENV
+              echo "modules=\"[
+                { \\\"cloudid\\\": \\\"gcp\\\", \\\"repo\\\": \\\"terraform-google-vmseries-modules\\\" }
+              ]\"" >> $GITHUB_ENV
               ;;
           esac
+
+
+
+          # case "${{ inputs.cloud-id }}" in
+          #   all)
+          #     echo "modules=[
+          #       { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
+          #       { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
+          #       { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' }
+          #     ]" >> $GITHUB_ENV
+          #     ;;
+          #   aws)
+          #     echo "modules=[
+          #       { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
+          #     ]" >> $GITHUB_ENV
+          #     ;;
+          #   azure)
+          #     echo "modules=[
+          #       { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
+          #     ]" >> $GITHUB_ENV
+          #     ;;
+          #   gcp)
+          #     echo "modules=[
+          #       { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' },
+          #     ]" >> $GITHUB_ENV
+          #     ;;
+          # esac
 
 
       # - name: Set matrix based on cloud-id

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,16 +27,16 @@ jobs:
         id: process_cloud_choice
         run: |
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            JSON="{ \"clouds\" : [ \"aws\" ] }"
+            JSON="{ [ \"aws\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            JSON="{ \"clouds\" : [ \"azure\" ] }"
+            JSON="{ [ \"azure\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            JSON="{ \"clouds\" : [ \"gcp\" ] }"
+            JSON="{ [ \"gcp\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            JSON="{ \"clouds\" : [ \"aws\", \"azure\", \"gcp\" ] }"
+            JSON="{ [ \"aws\", \"azure\", \"gcp\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           fi
 
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds).clouds }}
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -33,8 +33,8 @@ jobs:
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
             JSON_OLD2="{\"include\": [ \"aws\" ] }"
-            JSON_OLD3="{ \"clouds\" : [ \"aws\" ] }"
-            JSON="{ \"client_payload\" : { \"versions\" : [12, 14, 16] } }"
+            JSON_FAKE="{ \"client_payload\" : { \"versions\" : [12, 14, 16] } }"
+            JSON="{ clouds : [ aws ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -69,7 +69,6 @@ jobs:
 
               echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
               echo "ENV REPO: ${{ env.repo }}"
-              echo "REPO: ${{ repo }}"
 
       - name: Checkout module repo for ${{ matrix.modules.cloudid }}
         uses: actions/checkout@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,7 +32,8 @@ jobs:
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
-            JSON="{\"include\": [ \"aws\" ] }"
+            JSON_OLD2="{\"include\": [ \"aws\" ] }"
+            JSON="{ \"aws\" }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
@@ -56,8 +57,8 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.include) }}
+      # matrix:
+      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,7 +32,8 @@ jobs:
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
-            JSON="{ [ \"aws\" ] }"
+            JSON_FAIL="{ \"aws\" }"
+            JSON_STRING=[ "aws" ]
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
@@ -56,8 +57,8 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
+      # matrix:
+      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -33,7 +33,7 @@ jobs:
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
             JSON_OLD2="{\"include\": [ \"aws\" ] }"
-            JSON="{ \"aws\" }"
+            JSON="{ \"clouds\" : [ \"aws\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -56,8 +56,8 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      # matrix:
-      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
+      matrix:
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,110 +15,308 @@ on:
           - azure
           - gcp
 
-jobs:
+          #
+          # ORIGINAL MATRIX
+          #
+          # matrix:
+          #   modules:
+          #     - cloudid: aws
+          #       repo: 'terraform-aws-vmseries-modules'
+          #     - cloudid: azure
+          #       repo: 'terraform-azurerm-vmseries-modules'
+          #     - cloudid: gcp
+          #       repo: 'terraform-google-vmseries-modules'
 
+################ PLAN ##############
+#
+# CASE:
+#   aws - GH_OUT: cloud=aws, repo=aws
+#   azure - GH_OUT: cloud=aws, repo=aws
+#   gcp - GH_OUT: cloud=aws, repo=aws
+#   all -  - GH_OUT: cloud=aws, repo=aws, cloud=zure
+
+
+
+
+jobs:
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
-    # env:
-    #   clouds: ''
     outputs:
-      clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
+      JSON_ARRAY: ${{ steps.set_modules.outputs.JSON_ARRAY }}
     steps:
-      - name: Process choice of cloud(s) for matrix
-        id: process_cloud_choice
+      - name: Set modules variable for matrix
+        id: set_modules
         run: |
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
+          case "${{ inputs.cloud-id }}" in
+            all)
+              jsonArrayString="{ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }"
+              echo "JSON_ARRAY=$jsonArrayString" >> $GITHUB_OUTPUT
+              ;;
+            aws)
+              # echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_OUTPUT
+              echo "JSON_ARRAY={ \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }" >> $GITHUB_OUTPUT
+              ;;
+            azure)
+              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_OUTPUT
+              ;;
+            gcp)
+              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_OUTPUT
+              ;;
+          esac
 
-          if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            JSON="{ \"cloud_list\": [ \"aws\" ] }"
-            echo "JSON IS: $JSON"
-            echo "clouds=$JSON" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            echo "clouds=['azure']" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            echo "clouds=['gcp']" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            echo "clouds=['aws','azure','gcp']" >> $GITHUB_OUTPUT
-          fi
+      - name: Show JASON
+        run: |
+          echo "$JSON_ARRAY"
+      - name: Show JASON_NOT
+        run: |
+          echo "${{ fromJSON('{ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }').cloudid }}"
 
-        #   echo "${{ env.clouds }}"
+      # - name: Set matrix based on cloud-id
+      #   id: matrix
+      #   run: |
+      #     echo "::set-output name=matrix::[{}]"
+      #     case "${{ github.event.inputs.cloud-id }}" in
+      #       aws)
+      #         echo "::set-output name=cloudid::aws"
+      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules'"
+      #         ;;
+      #       azure)
+      #         echo "::set-output name=cloudid::azure"
+      #         echo "::set-output name=repo::'terraform-azurerm-vmseries-modules'"
+      #         ;;
+      #       gcp)
+      #         echo "::set-output name=cloudid::gcp"
+      #         echo "::set-output name=repo::'terraform-google-vmseries-modules'"
+      #         ;;
+      #       all)
+      #         echo "::set-output name=cloudid::all"
+      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules', 'terraform-azurerm-vmseries-modules', 'terraform-google-vmseries-modules'"
+      #         ;;
+      #     }
 
-      - name: Show CLOUDS
-        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
+  # setup-matrix:
+  #   name: Create matrix
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Create matrix variable
+  #       run: |
+  #         echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
+
+  #         if [[ "${{ inputs.cloud_id }}" == "aws" ]]; then
+  #           echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+  #         elif [[ "${{ inputs.cloud_id }}" == "gcp" ]]; then
+  #           echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+  #         elif [[ "${{ inputs.cloud_id }}" == "azure" ]]; then
+  #           echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+  #         elif [[ "${{ inputs.cloud_id }}" == "all" ]]; then
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #         fi
+  #       # To use a $GITHU_OUTPUT var: env.var_name
+
+      # matrix:
+      #   include:
+      #     - modules.cloudid: aws
+      #       modules.repo: 'terraform-aws-vmseries-modules'
+      #       if: ${{ inputs.cloud-id == 'aws' || inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: azure
+      #       modules.repo: 'terraform-azurerm-vmseries-modules'
+      #       if: ${{ inputs.cloud-id == 'azure' || inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: gcp
+      #       cloudid: gcp
+      #       modules.repo: 'terraform-google-vmseries-modules'
+      #       repo: 'terraform-google-vmseries-modules'
+      #       if: ${{ inputs.cloud-id == 'gcp' || inputs.cloud-id == 'all' }}
+
 
   generate-docs:
+    # name: Generate ${{ matrix.modules.cloudid }} module docs
     name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
     needs: generate-matrix
-    env:
-      repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-    #   matrix:
-    #     cloudid: ${{ needs.generate-matrix.outputs.clouds }}
+      matrix:
+        ${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}
+
+
+
+        # include:
+        #   # AWS
+        #   - inputs.cloud-id: aws
+        #     cloudid: aws
+        #     repo: 'terraform-aws-vmseries-modules'
+        #   - inputs.cloud-id: all
+        #     cloudid: aws
+        #     repo: 'terraform-aws-vmseries-modules'
+        #   # Azure
+        #   - inputs.cloud-id: azure
+        #     cloudid: azure
+        #     repo: 'terraform-azurerm-vmseries-modules'
+        #   - inputs.cloud-id: all
+        #     cloudid: azure
+        #     repo: 'terraform-azurerm-vmseries-modules'
+        #   # GCP
+        #   - inputs.cloud-id: gcp
+        #     cloudid: gcp
+        #     repo: 'terraform-google-vmseries-modules'
+        #   - inputs.cloud-id: all
+        #     cloudid: gcp
+        #     repo: 'terraform-google-vmseries-modules'
+
+
+      # matrix:
+      #   modules:
+      #     - cloudid: aws
+      #       repo: 'terraform-aws-vmseries-modules'
+      #     - cloudid: azure
+      #       repo: 'terraform-azurerm-vmseries-modules'
+      #     - cloudid: gcp
+      #       repo: 'terraform-google-vmseries-modules'
+
+      # matrix:
+      #   modules:
+      #     - requested_cloud_id: ${{ github.event.inputs.cloudid }}
+      #       include:
+      #         - requested_cloud_id: aws
+      #           cloud_id: aws
+      #           repo: 'terraform-aws-vmseries-modules'
+      #         - requested_cloud_id: azure
+      #           cloud_id: azure
+      #           repo: 'terraform-azurerm-vmseries-modules'
+      #         - requested_cloud_id: gcp
+      #           cloud_id: gcp
+      #           repo: 'terraform-google-vmseries-modules'
+      #         - requested_cloud_id: all
+      #           - cloud_id: aws
+      #             repo: 'terraform-aws-vmseries-modules'
+      #           - cloud_id: azure
+      #             repo: 'terraform-azurerm-vmseries-modules'
+      #           - cloud_id: gcp
+      #             repo: 'terraform-google-vmseries-modules'
+
+      # matrix:
+      #   include:
+      #     - modules.cloudid: aws
+      #       modules.repo: 'terraform-aws-vmseries-modules'
+      #       if: ${{ github.event.inputs.cloud-id == 'aws' || github.event.inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: azure
+      #       modules.repo: 'terraform-azurerm-vmseries-modules'
+      #       if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: gcp
+      #       cloudid: gcp
+      #       modules.repo: 'terraform-google-vmseries-modules'
+      #       repo: 'terraform-google-vmseries-modules'
+      #       if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
+
+
+
 
     steps:
-      - name: Set repo env
-        env:
-          TEMP: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
-        run: |
-          echo "CLOUDS MATRIX: $TEMP"
-
-          if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
-              echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
-              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.cloudid }}" == "azure" ]]; then
-              echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
-              fi
-
-              echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
-              echo "ENV REPO: ${{ env.repo }}"
-
-      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
-        uses: actions/checkout@v3
-        with:
-          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
-          path: ${{ matrix.modules.repo }}
       
-      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
+      # - name: Show modules
+      #   run: |
+      #     echo "${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}"
+
+      - name: Show input cloud-id
+        run: |
+          echo "${{ inputs.cloud-id }}"
+
+      # - name: Show intput cloudid (fails, must be "cloud-id")
+      #   run: |
+      #     echo "${{ inputs.cloudid }}"
+
+      # - name: Show matrix modules cloudid
+      #   run: |
+      #     echo "${{ matrix.modules.cloudid }}"
+ 
+      # - name: Show matrix modules repo
+      #   run: |
+      #     echo "${{ matrix.modules.repo }}"
+
+      - name: Show matrix cloudid
+        run: |
+          echo "${{ matrix.cloudid }}"
+  
+      - name: Show matrix repo
+        run: |
+          echo "${{ matrix.repo }}"
+
+      # - name: I can haz if?
+      #   run: |
+      #     echo "${{ matrix.if }}"
+  
+
+      # - name: Set repo variable based on cloud_id
+      #   run: |
+      #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then
+      #       echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+      #     elif [[ "${{ matrix.cloud_id }}" == "gcp" ]]; then
+      #       echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+      #     elif [[ "${{ matrix.cloud_id }}" == "azure" ]]; then
+      #       echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+      #     elif [[ "${{ matrix.cloud_id }}" == "all" ]]; then
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #     fi
+      #   # To use a $GITHU_OUTPUT var: env.var_name
+
+
+
+
+      # - name: Checkout module repo for ${{ matrix.modules.cloudid }}
+      - name: Checkout module repo for ${{ matrix.cloudid }}
         uses: actions/checkout@v3
         with:
-          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
-          path: ${{ matrix.modules.repo }}
-        
+          # repository: PaloAltoNetworks/${{ matrix.modules.repo }}
+          # path: ${{ matrix.modules.repo }}
+          repository: PaloAltoNetworks/${{ matrix.repo }}
+          path: ${{ matrix.repo }}
+
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/checkout@v3
         with:
           path: 'scripts'
-        
+
       - name: Setup Python
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip' # caching pip dependencies
-        
+
       - name: Install Python Dependencies
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           python -m pip install --upgrade pip
           pip install -r ./scripts/requirements.txt
-        
+
       - name: Generate module readmes for pan.dev
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           tree .
-          python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
-          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
-              
+          # python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
+          # python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
+          python ./scripts/process_modules_readmes.py "./${{ matrix.repo }}/modules" "./output/vmseries/modules"
+          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.repo }}/examples" "./output/vmseries/reference-architectures"
+      
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.modules.cloudid }}
+          # name: ${{ matrix.modules.cloudid }}
+          name: ${{ matrix.cloudid }}
           path: output
       
   
@@ -204,3 +402,4 @@ jobs:
         if: steps.create-pull-request.outputs.pull-request-number
         run: |
           echo "::notice ::PR ${{ steps.create-pull-request.outputs.pull-request-operation }}: ${{ steps.create-pull-request.outputs.pull-request-url }}"
+        

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -70,7 +70,7 @@ jobs:
           echo "$JSON_ARRAY"
       - name: Show JASON_NOT
         run: |
-          echo "${{ fromJSON('{ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }') }}"
+          echo "${{ fromJSON('{ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }') }}"
 
       # - name: Set matrix based on cloud-id
       #   id: matrix

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,11 @@ on:
           - azure
           - gcp
 
-jobs:  
+jobs:
+  # setup-matrix:
+  #   name: Generate matrix
+  #   runs-on: ubuntu-latest
+  
   generate-docs:
     # name: Generate ${{ matrix.modules.cloudid }} module docs
     name: Generate ${{ matrix.cloudid }} module docs
@@ -53,19 +57,44 @@ jobs:
       #           - cloud_id: gcp
       #             repo: 'terraform-google-vmseries-modules'
 
+      # matrix:
+      #   include:
+      #     - modules.cloudid: aws
+      #       modules.repo: 'terraform-aws-vmseries-modules'
+      #       if: ${{ github.event.inputs.cloud-id == 'aws' || github.event.inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: azure
+      #       modules.repo: 'terraform-azurerm-vmseries-modules'
+      #       if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: gcp
+      #       cloudid: gcp
+      #       modules.repo: 'terraform-google-vmseries-modules'
+      #       repo: 'terraform-google-vmseries-modules'
+      #       if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
+
+
       matrix:
         include:
-          - modules.cloudid: aws
-            modules.repo: 'terraform-aws-vmseries-modules'
-            if: ${{ github.event.inputs.cloud-id == 'aws' || github.event.inputs.cloud-id == 'all' }}
-          - modules.cloudid: azure
-            modules.repo: 'terraform-azurerm-vmseries-modules'
-            if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
-          - modules.cloudid: gcp
+          # AWS
+          - github.event.inputs.cloud-id: aws
+            cloudid: aws
+            repo: 'terraform-aws-vmseries-modules'
+          - github.event.inputs.cloud-id: all
+            cloudid: aws
+            repo: 'terraform-aws-vmseries-modules'
+          # Azure
+          - github.event.inputs.cloud-id: azure
+            cloudid: azure
+            repo: 'terraform-azurerm-vmseries-modules'
+          - github.event.inputs.cloud-id: all
+            cloudid: azure
+            repo: 'terraform-azurerm-vmseries-modules'
+          # GCP
+          - github.event.inputs.cloud-id: gcp
             cloudid: gcp
-            modules.repo: 'terraform-google-vmseries-modules'
             repo: 'terraform-google-vmseries-modules'
-            if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
+          - github.event.inputs.cloud-id: all
+            cloudid: gcp
+            repo: 'terraform-google-vmseries-modules'
 
     steps:
       - name: Show input cloud-id
@@ -76,13 +105,13 @@ jobs:
       #   run: |
       #     echo "${{ github.event.inputs.cloudid }}"
 
-      - name: Show matrix modules cloudid
-        run: |
-          echo "${{ matrix.modules.cloudid }}"
+      # - name: Show matrix modules cloudid
+      #   run: |
+      #     echo "${{ matrix.modules.cloudid }}"
  
-      - name: Show matrix modules repo
-        run: |
-          echo "${{ matrix.modules.repo }}"
+      # - name: Show matrix modules repo
+      #   run: |
+      #     echo "${{ matrix.modules.repo }}"
 
       - name: Show matrix cloudid
         run: |
@@ -92,9 +121,9 @@ jobs:
         run: |
           echo "${{ matrix.repo }}"
 
-      - name: I can haz if?
-        run: |
-          echo "${{ matrix.if }}"
+      # - name: I can haz if?
+      #   run: |
+      #     echo "${{ matrix.if }}"
   
 
       # - name: Set repo variable based on cloud_id
@@ -118,11 +147,14 @@ jobs:
 
 
 
-      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
+      # - name: Checkout module repo for ${{ matrix.modules.cloudid }}
+      - name: Checkout module repo for ${{ matrix.cloudid }}
         uses: actions/checkout@v3
         with:
-          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
-          path: ${{ matrix.modules.repo }}
+          # repository: PaloAltoNetworks/${{ matrix.modules.repo }}
+          # path: ${{ matrix.modules.repo }}
+          repository: PaloAltoNetworks/${{ matrix.repo }}
+          path: ${{ matrix.repo }}
 
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
@@ -147,14 +179,17 @@ jobs:
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           tree .
-          python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
-          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
+          # python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
+          # python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
+          python ./scripts/process_modules_readmes.py "./${{ matrix.repo }}/modules" "./output/vmseries/modules"
+          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.repo }}/examples" "./output/vmseries/reference-architectures"
       
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.modules.cloudid }}
+          # name: ${{ matrix.modules.cloudid }}
+          name: ${{ matrix.cloudid }}
           path: output
       
   

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Show CLOUDS 1
         run: echo "${{ needs.generate-matrix.outputs.clouds }}"
 
+      - name: Show CLOUDS 1a
+        run: echo "${{ toJSON(needs.generate-matrix.outputs.clouds) }}"
+
       - name: Show CLOUDS 2
         run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -31,23 +31,22 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
-            JSON_OLD2="{\"include\": [ \"aws\" ] }"
-            JSON_FAKE="{ \"client_payload\" : { \"versions\" : [12, 14, 16] } }"
             JSON="{ \"clouds\" : [ \"aws\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            echo "clouds=['azure']" >> $GITHUB_OUTPUT
+            JSON="{ \"clouds\" : [ \"azure\" ] }"
+            echo "JSON IS: $JSON"
+            echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            echo "clouds=['gcp']" >> $GITHUB_OUTPUT
+            JSON="{ \"clouds\" : [ \"gcp\" ] }"
+            echo "JSON IS: $JSON"
+            echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            JSON="{ \"clouds\" : [ \"aws\", \"azure\", \"google\" ] }"
+            JSON="{ \"clouds\" : [ \"aws\", \"azure\", \"gcp\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           fi
-
-        #   echo "${{ env.clouds }}"
 
       - name: Show CLOUDS
         run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
@@ -79,9 +78,9 @@ jobs:
         run: |
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_ENV
-          elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
-              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_ENV
           elif [[ "${{ matrix.cloudid }}" == "azure" ]]; then
+              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_ENV
+          elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
               echo "repo=terraform-google-vmseries-modules" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -59,8 +59,8 @@ jobs:
     steps:
       - name: Set repo env
         run: |
-          echo "CLOUDS MATRIX: ${{ needs.generate-matrix.outputs.clouds }}" # echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
-          echo "CLOUDS MATRIX FROM JASON: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+          echo "CLOUDS MATRIX TO_J: ${{ toJSON(needs.generate-matrix.outputs.clouds) }}"
+          echo "CLOUDS MATRIX FROM_J: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -42,7 +42,7 @@ jobs:
               ;;
           esac    
       - name: Show CLOUDS
-        run: echo "${{ clouds }}"
+        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -70,7 +70,7 @@ jobs:
           echo "$JSON_ARRAY"
       - name: Show JASON_NOT
         run: |
-          echo "${{ fromJSON('{ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }') }}"
+          echo "${{ fromJSON('{ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }').cloudid }}"
 
       # - name: Set matrix based on cloud-id
       #   id: matrix

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -60,8 +60,8 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      # matrix:
-      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
+      matrix:
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds).clouds }}
 
     steps:
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,8 +32,7 @@ jobs:
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
-            JSON_FAIL="{ \"aws\" }"
-            JSON_STRING=[ "aws" ]
+            JSON="{ [ \"aws\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,16 +51,16 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
           case "${{ inputs.cloud-id }}" in
             all)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "modules={ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "modules={ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" } ] }" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "modules={ "modules": [ { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" } ] }" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "modules={ "modules": [ { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }" >> $GITHUB_ENV
               ;;
           esac
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -65,6 +65,22 @@ jobs:
             # if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
 
     steps:
+      - name: Show input cloud-id
+        run: |
+          echo "${{ github.event.inputs.cloud-id }}"
+
+      - name: Show all inputs
+        run: |
+          echo "${{ github.event.inputs }}"
+
+      - name: Show matric cloudid
+        run: |
+          echo "${{ matrix.modules.cloudid }}"
+ 
+      - name: Show matric repo
+        run: |
+          echo "${{ matrix.modules.repo }}"
+    
       # - name: Set repo variable based on cloud_id
       #   run: |
       #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -33,7 +33,8 @@ jobs:
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
             JSON_OLD2="{\"include\": [ \"aws\" ] }"
-            JSON="{ \"clouds\" : [ \"aws\" ] }"
+            JSON_OLD3="{ \"clouds\" : [ \"aws\" ] }"
+            JSON="{ \"client_payload\" : { \"versions\" : [12, 14, 16] } }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
@@ -59,13 +60,13 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      # matrix:
-      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
+      matrix:
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.client_payload.versions) }}
 
     steps:
       - name: Set repo env
         run: |
-          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}.clouds"
+          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -16,7 +16,6 @@ on:
           - gcp
 
 jobs:
-
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -61,33 +61,33 @@ jobs:
         with:
           repository: PaloAltoNetworks/${{ env.repo }}
           path: ${{ env.repo }}
-        
+
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/checkout@v3
         with:
           path: 'scripts'
-        
+
       - name: Setup Python
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip' # caching pip dependencies
-        
+
       - name: Install Python Dependencies
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           python -m pip install --upgrade pip
           pip install -r ./scripts/requirements.txt
-        
+
       - name: Generate module readmes for pan.dev
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           tree .
           python ./scripts/process_modules_readmes.py "./${{ env.repo }}/modules" "./output/vmseries/modules"
           python ./scripts/process_modules_readmes.py --type refarch "./${{ env.repo }}/examples" "./output/vmseries/reference-architectures"
-              
+
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -34,7 +34,7 @@ jobs:
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
             JSON_OLD2="{\"include\": [ \"aws\" ] }"
             JSON_FAKE="{ \"client_payload\" : { \"versions\" : [12, 14, 16] } }"
-            JSON="{ clouds : [ aws ] }"
+            JSON="{ \"clouds\" : [ \"aws\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
@@ -66,13 +66,13 @@ jobs:
     steps:
 
       - name: Show CLOUDS 1
-        run: echo "CLOUDS MATRIX ${{ needs.generate-matrix.outputs.clouds }}"
+        run: echo "${{ needs.generate-matrix.outputs.clouds }}"
 
       - name: Show CLOUDS 2
-        run: echo "CLOUDS MATRIX ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+        run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 
       - name: Show CLOUDS 3
-        run: echo "CLOUDS MATRIX ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
+        run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
 
       - name: Set repo env
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -20,36 +20,26 @@ jobs:
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
-    # env:
-    #   clouds: ''
     outputs:
       clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
     steps:
       - name: Process choice of cloud(s) for matrix
         id: process_cloud_choice
         run: |
-          echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON="{ \"clouds\" : [ \"aws\" ] }"
-            echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
             JSON="{ \"clouds\" : [ \"azure\" ] }"
-            echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
             JSON="{ \"clouds\" : [ \"gcp\" ] }"
-            echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
             JSON="{ \"clouds\" : [ \"aws\", \"azure\", \"gcp\" ] }"
-            echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           fi
 
-      - name: Show CLOUDS
-        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs
@@ -61,19 +51,6 @@ jobs:
         cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds).clouds }}
 
     steps:
-
-      - name: Show CLOUDS 1
-        run: echo "${{ needs.generate-matrix.outputs.clouds }}"
-
-      - name: Show CLOUDS 1a
-        run: echo "${{ toJSON(needs.generate-matrix.outputs.clouds) }}"
-
-      - name: Show CLOUDS 2
-        run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
-
-      - name: Show CLOUDS 3
-        run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds).clouds }}"
-
       - name: Set repo env
         run: |
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
@@ -83,8 +60,6 @@ jobs:
           elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
               echo "repo=terraform-google-vmseries-modules" >> $GITHUB_ENV
           fi
-
-          echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
 
       - name: Checkout module repo for ${{ matrix.cloudid }}
         uses: actions/checkout@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -43,7 +43,7 @@ jobs:
     name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
-      modules: ${{ steps.set_modules.outputs.modules }}
+      JSON_ARRAY: ${{ steps.set_modules.outputs.JSON_ARRAY }}
     steps:
       - name: Set modules variable for matrix
         id: set_modules
@@ -51,16 +51,17 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
           case "${{ inputs.cloud-id }}" in
             all)
-              echo "modules={ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }" >> $GITHUB_ENV
+              jsonArrayString="{ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }"
+              echo "JSON_ARRAY=$jsonArrayString" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules={ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" } ] }" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules={ "modules": [ { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" } ] }" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules={ "modules": [ { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }" >> $GITHUB_ENV
+              echo "modules={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
               ;;
           esac
 
@@ -215,7 +216,7 @@ jobs:
       
       - name: Show modules
         run: |
-          echo "${{ fromJSON(needs.generate-matrix.outputs.modules) }}"
+          echo "${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}"
 
       - name: Show input cloud-id
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,16 +51,16 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
           case "${{ inputs.cloud-id }}" in
             all)
-              echo "modules=[ { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' }, { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' }, { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' } ]" >> $GITHUB_ENV
+              echo "modules=[ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ]" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules=[ { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' } ]" >> $GITHUB_ENV
+              echo "modules=[ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ]" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules=[ { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' } ]" >> $GITHUB_ENV
+              echo "modules=[ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ]" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules=[ { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' } ]" >> $GITHUB_ENV
+              echo "modules=[ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ]" >> $GITHUB_ENV
               ;;
           esac
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:  
   generate-docs:
-    name: Generate ${{ matrix.modules.cloudid }} module docs
+    # name: Generate ${{ matrix.modules.cloudid }} module docs
+    name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # treat each job as separate
@@ -71,9 +72,9 @@ jobs:
         run: |
           echo "${{ github.event.inputs.cloud-id }}"
 
-      - name: Show intput cloudid (does this matter?)
-        run: |
-          echo "${{ github.event.inputs.cloudid }}"
+      # - name: Show intput cloudid (does this matter?)
+      #   run: |
+      #     echo "${{ github.event.inputs.cloudid }}"
 
       - name: Show matrix modules cloudid
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -58,9 +58,10 @@ jobs:
 
     steps:
       - name: Set repo env
+        env:
+          TEMP: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
         run: |
-          echo "CLOUDS MATRIX TO_J: ${{ toJSON(needs.generate-matrix.outputs.clouds) }}"
-          echo "CLOUDS MATRIX FROM_J: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+          echo "CLOUDS MATRIX: $TEMP"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -75,35 +75,35 @@ jobs:
       matrix:
         include:
           # AWS
-          - github.event.inputs.cloud-id: aws
+          - inputs.cloud-id: aws
             cloudid: aws
             repo: 'terraform-aws-vmseries-modules'
-          - github.event.inputs.cloud-id: all
+          - inputs.cloud-id: all
             cloudid: aws
             repo: 'terraform-aws-vmseries-modules'
           # Azure
-          - github.event.inputs.cloud-id: azure
+          - inputs.cloud-id: azure
             cloudid: azure
             repo: 'terraform-azurerm-vmseries-modules'
-          - github.event.inputs.cloud-id: all
+          - inputs.cloud-id: all
             cloudid: azure
             repo: 'terraform-azurerm-vmseries-modules'
           # GCP
-          - github.event.inputs.cloud-id: gcp
+          - inputs.cloud-id: gcp
             cloudid: gcp
             repo: 'terraform-google-vmseries-modules'
-          - github.event.inputs.cloud-id: all
+          - inputs.cloud-id: all
             cloudid: gcp
             repo: 'terraform-google-vmseries-modules'
 
     steps:
       - name: Show input cloud-id
         run: |
-          echo "${{ github.event.inputs.cloud-id }}"
+          echo "${{ inputs.cloud-id }}"
 
       # - name: Show intput cloudid (fails, must be "cloud-id")
       #   run: |
-      #     echo "${{ github.event.inputs.cloudid }}"
+      #     echo "${{ inputs.cloudid }}"
 
       # - name: Show matrix modules cloudid
       #   run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,309 +15,106 @@ on:
           - azure
           - gcp
 
-          #
-          # ORIGINAL MATRIX
-          #
-          # matrix:
-          #   modules:
-          #     - cloudid: aws
-          #       repo: 'terraform-aws-vmseries-modules'
-          #     - cloudid: azure
-          #       repo: 'terraform-azurerm-vmseries-modules'
-          #     - cloudid: gcp
-          #       repo: 'terraform-google-vmseries-modules'
-
-################ PLAN ##############
-#
-# CASE:
-#   aws - GH_OUT: cloud=aws, repo=aws
-#   azure - GH_OUT: cloud=aws, repo=aws
-#   gcp - GH_OUT: cloud=aws, repo=aws
-#   all -  - GH_OUT: cloud=aws, repo=aws, cloud=zure
-
-
-
-
 jobs:
+
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
-      JSON_ARRAY: ${{ steps.set_modules.outputs.JSON_ARRAY }}
+      clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
     steps:
-      - name: Set modules variable for matrix
-        id: set_modules
+      - name: Process choice of cloud(s) for matrix
+        id: process_cloud_choice
         run: |
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
           case "${{ inputs.cloud-id }}" in
             all)
-              jsonArrayString="{ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }"
-              echo "JSON_ARRAY=$jsonArrayString" >> $GITHUB_ENV
+              echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
               ;;
             aws)
-              # echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
-              echo "JSON_ARRAY={ \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }" >> $GITHUB_ENV
+              echo "clouds=['aws']" >> $GITHUB_ENV
               ;;
             azure)
-              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "clouds=['azure']" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "clouds=['gcp']" >> $GITHUB_ENV
               ;;
-          esac
-
-      - name: Show JASON
-        run: |
-          echo "$JSON_ARRAY"
-      - name: Show JASON_NOT
-        run: |
-          echo "${{ fromJSON('{ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }').cloudid }}"
-
-      # - name: Set matrix based on cloud-id
-      #   id: matrix
-      #   run: |
-      #     echo "::set-output name=matrix::[{}]"
-      #     case "${{ github.event.inputs.cloud-id }}" in
-      #       aws)
-      #         echo "::set-output name=cloudid::aws"
-      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules'"
-      #         ;;
-      #       azure)
-      #         echo "::set-output name=cloudid::azure"
-      #         echo "::set-output name=repo::'terraform-azurerm-vmseries-modules'"
-      #         ;;
-      #       gcp)
-      #         echo "::set-output name=cloudid::gcp"
-      #         echo "::set-output name=repo::'terraform-google-vmseries-modules'"
-      #         ;;
-      #       all)
-      #         echo "::set-output name=cloudid::all"
-      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules', 'terraform-azurerm-vmseries-modules', 'terraform-google-vmseries-modules'"
-      #         ;;
-      #     }
-
-  # setup-matrix:
-  #   name: Create matrix
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Create matrix variable
-  #       run: |
-  #         echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-
-  #         if [[ "${{ inputs.cloud_id }}" == "aws" ]]; then
-  #           echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
-  #         elif [[ "${{ inputs.cloud_id }}" == "gcp" ]]; then
-  #           echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
-  #         elif [[ "${{ inputs.cloud_id }}" == "azure" ]]; then
-  #           echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
-  #         elif [[ "${{ inputs.cloud_id }}" == "all" ]]; then
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #         fi
-  #       # To use a $GITHU_OUTPUT var: env.var_name
-
-      # matrix:
-      #   include:
-      #     - modules.cloudid: aws
-      #       modules.repo: 'terraform-aws-vmseries-modules'
-      #       if: ${{ inputs.cloud-id == 'aws' || inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: azure
-      #       modules.repo: 'terraform-azurerm-vmseries-modules'
-      #       if: ${{ inputs.cloud-id == 'azure' || inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: gcp
-      #       cloudid: gcp
-      #       modules.repo: 'terraform-google-vmseries-modules'
-      #       repo: 'terraform-google-vmseries-modules'
-      #       if: ${{ inputs.cloud-id == 'gcp' || inputs.cloud-id == 'all' }}
-
+          esac    
+      - name: Show CLOUDS
+        run: echo "${{ clouds }}"
 
   generate-docs:
-    # name: Generate ${{ matrix.modules.cloudid }} module docs
     name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
-    needs: generate-matrix
+    env:
+      repo: ''
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        ${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}
-
-
-
-        # include:
-        #   # AWS
-        #   - inputs.cloud-id: aws
-        #     cloudid: aws
-        #     repo: 'terraform-aws-vmseries-modules'
-        #   - inputs.cloud-id: all
-        #     cloudid: aws
-        #     repo: 'terraform-aws-vmseries-modules'
-        #   # Azure
-        #   - inputs.cloud-id: azure
-        #     cloudid: azure
-        #     repo: 'terraform-azurerm-vmseries-modules'
-        #   - inputs.cloud-id: all
-        #     cloudid: azure
-        #     repo: 'terraform-azurerm-vmseries-modules'
-        #   # GCP
-        #   - inputs.cloud-id: gcp
-        #     cloudid: gcp
-        #     repo: 'terraform-google-vmseries-modules'
-        #   - inputs.cloud-id: all
-        #     cloudid: gcp
-        #     repo: 'terraform-google-vmseries-modules'
-
-
-      # matrix:
-      #   modules:
-      #     - cloudid: aws
-      #       repo: 'terraform-aws-vmseries-modules'
-      #     - cloudid: azure
-      #       repo: 'terraform-azurerm-vmseries-modules'
-      #     - cloudid: gcp
-      #       repo: 'terraform-google-vmseries-modules'
-
-      # matrix:
-      #   modules:
-      #     - requested_cloud_id: ${{ github.event.inputs.cloudid }}
-      #       include:
-      #         - requested_cloud_id: aws
-      #           cloud_id: aws
-      #           repo: 'terraform-aws-vmseries-modules'
-      #         - requested_cloud_id: azure
-      #           cloud_id: azure
-      #           repo: 'terraform-azurerm-vmseries-modules'
-      #         - requested_cloud_id: gcp
-      #           cloud_id: gcp
-      #           repo: 'terraform-google-vmseries-modules'
-      #         - requested_cloud_id: all
-      #           - cloud_id: aws
-      #             repo: 'terraform-aws-vmseries-modules'
-      #           - cloud_id: azure
-      #             repo: 'terraform-azurerm-vmseries-modules'
-      #           - cloud_id: gcp
-      #             repo: 'terraform-google-vmseries-modules'
-
-      # matrix:
-      #   include:
-      #     - modules.cloudid: aws
-      #       modules.repo: 'terraform-aws-vmseries-modules'
-      #       if: ${{ github.event.inputs.cloud-id == 'aws' || github.event.inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: azure
-      #       modules.repo: 'terraform-azurerm-vmseries-modules'
-      #       if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: gcp
-      #       cloudid: gcp
-      #       modules.repo: 'terraform-google-vmseries-modules'
-      #       repo: 'terraform-google-vmseries-modules'
-      #       if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
-
-
-
+        cloudid: ${{ needs.generate-matrix.outputs.clouds }}
 
     steps:
-      
-      # - name: Show modules
-      #   run: |
-      #     echo "${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}"
-
-      - name: Show input cloud-id
+      - name: Set repo env
         run: |
-          echo "${{ inputs.cloud-id }}"
+          echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
 
-      # - name: Show intput cloudid (fails, must be "cloud-id")
-      #   run: |
-      #     echo "${{ inputs.cloudid }}"
+          if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
+              echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
+              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.cloudid }}" == "azure" ]]; then
+              echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+              fi
 
-      # - name: Show matrix modules cloudid
-      #   run: |
-      #     echo "${{ matrix.modules.cloudid }}"
- 
-      # - name: Show matrix modules repo
-      #   run: |
-      #     echo "${{ matrix.modules.repo }}"
+              echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
+              echo "ENV REPO: ${{ env.repo }}"
+              echo "REPO: ${{ repo }}"
 
-      - name: Show matrix cloudid
-        run: |
-          echo "${{ matrix.cloudid }}"
-  
-      - name: Show matrix repo
-        run: |
-          echo "${{ matrix.repo }}"
-
-      # - name: I can haz if?
-      #   run: |
-      #     echo "${{ matrix.if }}"
-  
-
-      # - name: Set repo variable based on cloud_id
-      #   run: |
-      #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then
-      #       echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
-      #     elif [[ "${{ matrix.cloud_id }}" == "gcp" ]]; then
-      #       echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
-      #     elif [[ "${{ matrix.cloud_id }}" == "azure" ]]; then
-      #       echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
-      #     elif [[ "${{ matrix.cloud_id }}" == "all" ]]; then
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #     fi
-      #   # To use a $GITHU_OUTPUT var: env.var_name
-
-
-
-
-      # - name: Checkout module repo for ${{ matrix.modules.cloudid }}
-      - name: Checkout module repo for ${{ matrix.cloudid }}
+      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
         uses: actions/checkout@v3
         with:
-          # repository: PaloAltoNetworks/${{ matrix.modules.repo }}
-          # path: ${{ matrix.modules.repo }}
-          repository: PaloAltoNetworks/${{ matrix.repo }}
-          path: ${{ matrix.repo }}
-
+          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
+          path: ${{ matrix.modules.repo }}
+      
+      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
+        uses: actions/checkout@v3
+        with:
+          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
+          path: ${{ matrix.modules.repo }}
+        
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/checkout@v3
         with:
           path: 'scripts'
-
+        
       - name: Setup Python
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip' # caching pip dependencies
-
+        
       - name: Install Python Dependencies
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           python -m pip install --upgrade pip
           pip install -r ./scripts/requirements.txt
-
+        
       - name: Generate module readmes for pan.dev
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           tree .
-          # python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
-          # python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
-          python ./scripts/process_modules_readmes.py "./${{ matrix.repo }}/modules" "./output/vmseries/modules"
-          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.repo }}/examples" "./output/vmseries/reference-architectures"
-      
+          python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
+          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
+              
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3
         with:
-          # name: ${{ matrix.modules.cloudid }}
-          name: ${{ matrix.cloudid }}
-          path: output
+          name: ${{ matrix.modules.cloudid }}
+            path: output
       
   
   sync-to-pan-dev:
@@ -402,4 +199,3 @@ jobs:
         if: steps.create-pull-request.outputs.pull-request-number
         run: |
           echo "::notice ::PR ${{ steps.create-pull-request.outputs.pull-request-operation }}: ${{ steps.create-pull-request.outputs.pull-request-url }}"
-        

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Show JASON
         run: |
-          echo "${{ fromJSON(JSON_ARRAY) }}"
+          echo "$JSON_ARRAY"
 
       # - name: Set matrix based on cloud-id
       #   id: matrix

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -41,7 +41,9 @@ jobs:
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
             echo "clouds=['gcp']" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            echo "clouds=['aws','azure','gcp']" >> $GITHUB_OUTPUT
+            JSON="{ \"clouds\" : [ \"aws\", \"azure\", \"google\" ] }"
+            echo "JSON IS: $JSON"
+            echo "clouds=$JSON" >> $GITHUB_OUTPUT
           fi
 
         #   echo "${{ env.clouds }}"
@@ -57,13 +59,13 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
+      # matrix:
+      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
 
     steps:
       - name: Set repo env
         run: |
-          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}.clouds"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           echo "${{ github.event.inputs.cloud-id }}"
 
-      # - name: Show intput cloudid (does this matter?)
+      # - name: Show intput cloudid (fails, must be "cloud-id")
       #   run: |
       #     echo "${{ github.event.inputs.cloudid }}"
 
@@ -91,7 +91,12 @@ jobs:
       - name: Show matrix repo
         run: |
           echo "${{ matrix.repo }}"
+
+      - name: I can haz if?
+        run: |
+          echo "${{ matrix.if }}"
   
+
       # - name: Set repo variable based on cloud_id
       #   run: |
       #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -20,8 +20,8 @@ jobs:
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
-    env:
-      clouds: ''
+    # env:
+    #   clouds: ''
     outputs:
       clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
     steps:
@@ -40,10 +40,10 @@ jobs:
             echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
           fi
 
-          echo "${{ env.clouds }}"
+        #   echo "${{ env.clouds }}"
 
-      - name: Show CLOUDS
-        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
+    #   - name: Show CLOUDS
+    #     run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs
@@ -53,13 +53,13 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        cloudid: ${{ needs.generate-matrix.outputs.clouds }}
+    #   matrix:
+    #     cloudid: ${{ needs.generate-matrix.outputs.clouds }}
 
     steps:
       - name: Set repo env
         run: |
-          echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
+          echo "CLOUDS MATRIX ${{ needs.generate-matrix.outputs.clouds }}" # echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,16 +27,16 @@ jobs:
         id: process_cloud_choice
         run: |
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            JSON="{ [ \"aws\" ] }"
+            JSON="{ \"selected_clouds\" : [ \"aws\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            JSON="{ [ \"azure\" ] }"
+            JSON="{ \"selected_clouds\" : [ \"azure\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            JSON="{ [ \"gcp\" ] }"
+            JSON="{ \"selected_clouds\" : [ \"gcp\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            JSON="{ [ \"aws\", \"azure\", \"gcp\" ] }"
+            JSON="{ \"selected_clouds\" : [ \"aws\", \"azure\", \"gcp\" ] }"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           fi
 
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds).selected_clouds }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,308 +15,102 @@ on:
           - azure
           - gcp
 
-          #
-          # ORIGINAL MATRIX
-          #
-          # matrix:
-          #   modules:
-          #     - cloudid: aws
-          #       repo: 'terraform-aws-vmseries-modules'
-          #     - cloudid: azure
-          #       repo: 'terraform-azurerm-vmseries-modules'
-          #     - cloudid: gcp
-          #       repo: 'terraform-google-vmseries-modules'
-
-################ PLAN ##############
-#
-# CASE:
-#   aws - GH_OUT: cloud=aws, repo=aws
-#   azure - GH_OUT: cloud=aws, repo=aws
-#   gcp - GH_OUT: cloud=aws, repo=aws
-#   all -  - GH_OUT: cloud=aws, repo=aws, cloud=zure
-
-
-
-
 jobs:
+
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
+    # env:
+    #   clouds: ''
     outputs:
-      JSON_ARRAY: ${{ steps.set_modules.outputs.JSON_ARRAY }}
+      clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
     steps:
-      - name: Set modules variable for matrix
-        id: set_modules
+      - name: Process choice of cloud(s) for matrix
+        id: process_cloud_choice
         run: |
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-          case "${{ inputs.cloud-id }}" in
-            all)
-              jsonArrayString="{ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }"
-              echo "JSON_ARRAY=$jsonArrayString" >> $GITHUB_OUTPUT
-              ;;
-            aws)
-              # echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_OUTPUT
-              echo "JSON_ARRAY={ \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }" >> $GITHUB_OUTPUT
-              ;;
-            azure)
-              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_OUTPUT
-              ;;
-            gcp)
-              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }" >> $GITHUB_OUTPUT
-              ;;
-          esac
 
-      - name: Show JASON
-        run: |
-          echo "$JSON_ARRAY"
-      - name: Show JASON_NOT
-        run: |
-          echo "${{ fromJSON('{ "modules": [ { "cloudid": "aws", "repo": "terraform-aws-vmseries-modules" }, { "cloudid": "azure", "repo": "terraform-azurerm-vmseries-modules" }, { "cloudid": "gcp", "repo": "terraform-google-vmseries-modules" } ] }').cloudid }}"
+          if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
+            JSON="{ \"cloud_list\": [ \"aws\" ] }"
+            echo "JSON IS: $JSON"
+            echo "clouds=$JSON" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
+            echo "clouds=['azure']" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
+            echo "clouds=['gcp']" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
+            echo "clouds=['aws','azure','gcp']" >> $GITHUB_OUTPUT
+          fi
 
-      # - name: Set matrix based on cloud-id
-      #   id: matrix
-      #   run: |
-      #     echo "::set-output name=matrix::[{}]"
-      #     case "${{ github.event.inputs.cloud-id }}" in
-      #       aws)
-      #         echo "::set-output name=cloudid::aws"
-      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules'"
-      #         ;;
-      #       azure)
-      #         echo "::set-output name=cloudid::azure"
-      #         echo "::set-output name=repo::'terraform-azurerm-vmseries-modules'"
-      #         ;;
-      #       gcp)
-      #         echo "::set-output name=cloudid::gcp"
-      #         echo "::set-output name=repo::'terraform-google-vmseries-modules'"
-      #         ;;
-      #       all)
-      #         echo "::set-output name=cloudid::all"
-      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules', 'terraform-azurerm-vmseries-modules', 'terraform-google-vmseries-modules'"
-      #         ;;
-      #     }
+        #   echo "${{ env.clouds }}"
 
-  # setup-matrix:
-  #   name: Create matrix
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Create matrix variable
-  #       run: |
-  #         echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-
-  #         if [[ "${{ inputs.cloud_id }}" == "aws" ]]; then
-  #           echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
-  #         elif [[ "${{ inputs.cloud_id }}" == "gcp" ]]; then
-  #           echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
-  #         elif [[ "${{ inputs.cloud_id }}" == "azure" ]]; then
-  #           echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
-  #         elif [[ "${{ inputs.cloud_id }}" == "all" ]]; then
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #           echo "::set-output name=repo::azure-repo"
-  #         fi
-  #       # To use a $GITHU_OUTPUT var: env.var_name
-
-      # matrix:
-      #   include:
-      #     - modules.cloudid: aws
-      #       modules.repo: 'terraform-aws-vmseries-modules'
-      #       if: ${{ inputs.cloud-id == 'aws' || inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: azure
-      #       modules.repo: 'terraform-azurerm-vmseries-modules'
-      #       if: ${{ inputs.cloud-id == 'azure' || inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: gcp
-      #       cloudid: gcp
-      #       modules.repo: 'terraform-google-vmseries-modules'
-      #       repo: 'terraform-google-vmseries-modules'
-      #       if: ${{ inputs.cloud-id == 'gcp' || inputs.cloud-id == 'all' }}
-
+      - name: Show CLOUDS
+        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
-    # name: Generate ${{ matrix.modules.cloudid }} module docs
     name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
     needs: generate-matrix
+    env:
+      repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        ${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}
-
-
-
-        # include:
-        #   # AWS
-        #   - inputs.cloud-id: aws
-        #     cloudid: aws
-        #     repo: 'terraform-aws-vmseries-modules'
-        #   - inputs.cloud-id: all
-        #     cloudid: aws
-        #     repo: 'terraform-aws-vmseries-modules'
-        #   # Azure
-        #   - inputs.cloud-id: azure
-        #     cloudid: azure
-        #     repo: 'terraform-azurerm-vmseries-modules'
-        #   - inputs.cloud-id: all
-        #     cloudid: azure
-        #     repo: 'terraform-azurerm-vmseries-modules'
-        #   # GCP
-        #   - inputs.cloud-id: gcp
-        #     cloudid: gcp
-        #     repo: 'terraform-google-vmseries-modules'
-        #   - inputs.cloud-id: all
-        #     cloudid: gcp
-        #     repo: 'terraform-google-vmseries-modules'
-
-
-      # matrix:
-      #   modules:
-      #     - cloudid: aws
-      #       repo: 'terraform-aws-vmseries-modules'
-      #     - cloudid: azure
-      #       repo: 'terraform-azurerm-vmseries-modules'
-      #     - cloudid: gcp
-      #       repo: 'terraform-google-vmseries-modules'
-
-      # matrix:
-      #   modules:
-      #     - requested_cloud_id: ${{ github.event.inputs.cloudid }}
-      #       include:
-      #         - requested_cloud_id: aws
-      #           cloud_id: aws
-      #           repo: 'terraform-aws-vmseries-modules'
-      #         - requested_cloud_id: azure
-      #           cloud_id: azure
-      #           repo: 'terraform-azurerm-vmseries-modules'
-      #         - requested_cloud_id: gcp
-      #           cloud_id: gcp
-      #           repo: 'terraform-google-vmseries-modules'
-      #         - requested_cloud_id: all
-      #           - cloud_id: aws
-      #             repo: 'terraform-aws-vmseries-modules'
-      #           - cloud_id: azure
-      #             repo: 'terraform-azurerm-vmseries-modules'
-      #           - cloud_id: gcp
-      #             repo: 'terraform-google-vmseries-modules'
-
-      # matrix:
-      #   include:
-      #     - modules.cloudid: aws
-      #       modules.repo: 'terraform-aws-vmseries-modules'
-      #       if: ${{ github.event.inputs.cloud-id == 'aws' || github.event.inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: azure
-      #       modules.repo: 'terraform-azurerm-vmseries-modules'
-      #       if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
-      #     - modules.cloudid: gcp
-      #       cloudid: gcp
-      #       modules.repo: 'terraform-google-vmseries-modules'
-      #       repo: 'terraform-google-vmseries-modules'
-      #       if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
-
-
-
+    #   matrix:
+    #     cloudid: ${{ needs.generate-matrix.outputs.clouds }}
 
     steps:
-      
-      # - name: Show modules
-      #   run: |
-      #     echo "${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}"
-
-      - name: Show input cloud-id
+      - name: Set repo env
         run: |
-          echo "${{ inputs.cloud-id }}"
+          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 
-      # - name: Show intput cloudid (fails, must be "cloud-id")
-      #   run: |
-      #     echo "${{ inputs.cloudid }}"
+          if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
+              echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then
+              echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.cloudid }}" == "azure" ]]; then
+              echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+          fi
 
-      # - name: Show matrix modules cloudid
-      #   run: |
-      #     echo "${{ matrix.modules.cloudid }}"
- 
-      # - name: Show matrix modules repo
-      #   run: |
-      #     echo "${{ matrix.modules.repo }}"
+          echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
+          echo "ENV REPO: ${{ env.repo }}"
 
-      - name: Show matrix cloudid
-        run: |
-          echo "${{ matrix.cloudid }}"
-  
-      - name: Show matrix repo
-        run: |
-          echo "${{ matrix.repo }}"
-
-      # - name: I can haz if?
-      #   run: |
-      #     echo "${{ matrix.if }}"
-  
-
-      # - name: Set repo variable based on cloud_id
-      #   run: |
-      #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then
-      #       echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
-      #     elif [[ "${{ matrix.cloud_id }}" == "gcp" ]]; then
-      #       echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
-      #     elif [[ "${{ matrix.cloud_id }}" == "azure" ]]; then
-      #       echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
-      #     elif [[ "${{ matrix.cloud_id }}" == "all" ]]; then
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #       echo "::set-output name=repo::azure-repo"
-      #     fi
-      #   # To use a $GITHU_OUTPUT var: env.var_name
-
-
-
-
-      # - name: Checkout module repo for ${{ matrix.modules.cloudid }}
-      - name: Checkout module repo for ${{ matrix.cloudid }}
+      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
         uses: actions/checkout@v3
         with:
-          # repository: PaloAltoNetworks/${{ matrix.modules.repo }}
-          # path: ${{ matrix.modules.repo }}
-          repository: PaloAltoNetworks/${{ matrix.repo }}
-          path: ${{ matrix.repo }}
-
+          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
+          path: ${{ matrix.modules.repo }}
+        
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/checkout@v3
         with:
           path: 'scripts'
-
+        
       - name: Setup Python
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip' # caching pip dependencies
-
+        
       - name: Install Python Dependencies
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           python -m pip install --upgrade pip
           pip install -r ./scripts/requirements.txt
-
+        
       - name: Generate module readmes for pan.dev
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           tree .
-          # python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
-          # python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
-          python ./scripts/process_modules_readmes.py "./${{ matrix.repo }}/modules" "./output/vmseries/modules"
-          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.repo }}/examples" "./output/vmseries/reference-architectures"
-      
+          python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
+          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
+              
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3
         with:
-          # name: ${{ matrix.modules.cloudid }}
-          name: ${{ matrix.cloudid }}
+          name: ${{ matrix.modules.cloudid }}
           path: output
       
   
@@ -402,4 +196,3 @@ jobs:
         if: steps.create-pull-request.outputs.pull-request-number
         run: |
           echo "::notice ::PR ${{ steps.create-pull-request.outputs.pull-request-operation }}: ${{ steps.create-pull-request.outputs.pull-request-url }}"
-        

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Show JASON
         run: |
           echo "$JSON_ARRAY"
+      - name: Show JASON_NOT
+        run: |
+          echo "${{ fromJSON('{ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }, { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" }, { \"cloudid\": \"gcp\", \"repo\": \"terraform-google-vmseries-modules\" } ] }') }}"
 
       # - name: Set matrix based on cloud-id
       #   id: matrix

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,6 +26,60 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # treat each job as separate
+      matrix:
+        include:
+
+          # AWS
+          - inputs:
+              cloud-id: aws
+            cloudid: aws
+            repo: 'terraform-aws-vmseries-modules'
+          - inputs:
+              cloud-id: all
+            cloudid: aws
+            repo: 'terraform-aws-vmseries-modules'
+          # Azure
+          - inputs:
+              cloud-id: azure
+            cloudid: azure
+            repo: 'terraform-azurerm-vmseries-modules'
+          - inputs:
+              cloud-id: all
+            cloudid: azure
+            repo: 'terraform-azurerm-vmseries-modules'
+          # GCP
+          - inputs:
+              cloud-id: gcp
+            cloudid: gcp
+            repo: 'terraform-google-vmseries-modules'
+          - inputs:
+              cloud-id: all
+            cloudid: gcp
+            repo: 'terraform-google-vmseries-modules'
+
+
+          # # AWS
+          # - inputs.cloud-id: aws
+          #   cloudid: aws
+          #   repo: 'terraform-aws-vmseries-modules'
+          # - inputs.cloud-id: all
+          #   cloudid: aws
+          #   repo: 'terraform-aws-vmseries-modules'
+          # # Azure
+          # - inputs.cloud-id: azure
+          #   cloudid: azure
+          #   repo: 'terraform-azurerm-vmseries-modules'
+          # - inputs.cloud-id: all
+          #   cloudid: azure
+          #   repo: 'terraform-azurerm-vmseries-modules'
+          # # GCP
+          # - inputs.cloud-id: gcp
+          #   cloudid: gcp
+          #   repo: 'terraform-google-vmseries-modules'
+          # - inputs.cloud-id: all
+          #   cloudid: gcp
+          #   repo: 'terraform-google-vmseries-modules'
+
 
       # matrix:
       #   modules:
@@ -72,29 +126,7 @@ jobs:
       #       if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
 
 
-      matrix:
-        include:
-          # AWS
-          - inputs.cloud-id: aws
-            cloudid: aws
-            repo: 'terraform-aws-vmseries-modules'
-          - inputs.cloud-id: all
-            cloudid: aws
-            repo: 'terraform-aws-vmseries-modules'
-          # Azure
-          - inputs.cloud-id: azure
-            cloudid: azure
-            repo: 'terraform-azurerm-vmseries-modules'
-          - inputs.cloud-id: all
-            cloudid: azure
-            repo: 'terraform-azurerm-vmseries-modules'
-          # GCP
-          - inputs.cloud-id: gcp
-            cloudid: gcp
-            repo: 'terraform-google-vmseries-modules'
-          - inputs.cloud-id: all
-            cloudid: gcp
-            repo: 'terraform-google-vmseries-modules'
+
 
     steps:
       - name: Show input cloud-id

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Set repo env
         run: |
+          echo "CLOUDS MATRIX: ${{ needs.generate-matrix.outputs.clouds }}"
+          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
           echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -31,19 +31,21 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            echo "clouds={ \"cloud_list\": [ \"aws\" ] }" >> $GITHUB_ENV
+            JSON="{ \"cloud_list\": [ \"aws\" ] }"
+            echo "JSON IS: $JSON"
+            echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            echo "clouds=['azure']" >> $GITHUB_ENV
+            echo "clouds=['azure']" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            echo "clouds=['gcp']" >> $GITHUB_ENV
+            echo "clouds=['gcp']" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
+            echo "clouds=['aws','azure','gcp']" >> $GITHUB_OUTPUT
           fi
 
         #   echo "${{ env.clouds }}"
 
-    #   - name: Show CLOUDS
-    #     run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
+      - name: Show CLOUDS
+        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -61,7 +61,9 @@ jobs:
             modules.repo: 'terraform-azurerm-vmseries-modules'
             if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
           - modules.cloudid: gcp
+            cloudid: gcp
             modules.repo: 'terraform-google-vmseries-modules'
+            repo: 'terraform-google-vmseries-modules'
             # if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
 
     steps:
@@ -69,18 +71,26 @@ jobs:
         run: |
           echo "${{ github.event.inputs.cloud-id }}"
 
-      - name: Show all inputs
+      - name: Show intput cloudid (does this matter?)
         run: |
-          echo "${{ github.event.inputs }}"
+          echo "${{ github.event.inputs.cloudid }}"
 
-      - name: Show matric cloudid
+      - name: Show matrix modules cloudid
         run: |
           echo "${{ matrix.modules.cloudid }}"
  
-      - name: Show matric repo
+      - name: Show matrix modules repo
         run: |
           echo "${{ matrix.modules.repo }}"
-    
+
+      - name: Show matrix cloudid
+        run: |
+          echo "${{ matrix.cloudid }}"
+  
+      - name: Show matrix repo
+        run: |
+          echo "${{ matrix.repo }}"
+  
       # - name: Set repo variable based on cloud_id
       #   run: |
       #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -65,7 +65,7 @@ jobs:
             cloudid: gcp
             modules.repo: 'terraform-google-vmseries-modules'
             repo: 'terraform-google-vmseries-modules'
-            # if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
+            if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
 
     steps:
       - name: Show input cloud-id

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -56,8 +56,6 @@ jobs:
     name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
     needs: generate-matrix
-    env:
-      repo: ''
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
@@ -88,13 +86,12 @@ jobs:
           fi
 
           echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
-          echo "ENV REPO: ${{ env.repo }}"
 
-      - name: Checkout module repo for ${{ matrix.modules.cloudid }}
+      - name: Checkout module repo for ${{ matrix.cloudid }}
         uses: actions/checkout@v3
         with:
-          repository: PaloAltoNetworks/${{ matrix.modules.repo }}
-          path: ${{ matrix.modules.repo }}
+          repository: PaloAltoNetworks/${{ env.repo }}
+          path: ${{ env.repo }}
         
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
@@ -119,14 +116,14 @@ jobs:
         # if: steps.check_commit.outputs.changes != 'false'
         run: |
           tree .
-          python ./scripts/process_modules_readmes.py "./${{ matrix.modules.repo }}/modules" "./output/vmseries/modules"
-          python ./scripts/process_modules_readmes.py --type refarch "./${{ matrix.modules.repo }}/examples" "./output/vmseries/reference-architectures"
+          python ./scripts/process_modules_readmes.py "./${{ env.repo }}/modules" "./output/vmseries/modules"
+          python ./scripts/process_modules_readmes.py --type refarch "./${{ env.repo }}/examples" "./output/vmseries/reference-architectures"
               
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.modules.cloudid }}
+          name: ${{ matrix.cloudid }}
           path: output
       
   

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -75,7 +75,7 @@ jobs:
         run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 
       - name: Show CLOUDS 3
-        run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
+        run: echo "${{ fromJSON(needs.generate-matrix.outputs.clouds).clouds }}"
 
       - name: Set repo env
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -60,13 +60,13 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.client_payload.versions) }}
+      # matrix:
+      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
 
     steps:
       - name: Set repo env
         run: |
-          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -31,19 +31,19 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            echo "clouds=('aws')" >> $GITHUB_ENV
+            echo "clouds={ \"cloud_list\": [ \"aws\" ] }" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            echo "clouds=('azure')" >> $GITHUB_ENV
+            echo "clouds=['azure']" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            echo "clouds=('gcp')" >> $GITHUB_ENV
+            echo "clouds=['gcp']" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            echo "clouds=('aws','azure','gcp')" >> $GITHUB_ENV
+            echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
           fi
 
         #   echo "${{ env.clouds }}"
 
-      - name: Show CLOUDS
-        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
+    #   - name: Show CLOUDS
+    #     run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs
@@ -60,6 +60,7 @@ jobs:
       - name: Set repo env
         run: |
           echo "CLOUDS MATRIX: ${{ needs.generate-matrix.outputs.clouds }}" # echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
+          echo "CLOUDS MATRIX FROM JASON: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,23 +19,20 @@ jobs:
   generate-matrix:
     name: Generate Matrix
     runs-on: ubuntu-latest
-    outputs:
+    outputs: # this job outputs a matrix for the next job
       clouds: ${{ steps.process_cloud_choice.outputs.clouds }}
-    steps:
+    steps: # this step looks at the cloud inputs and creates a relevant matrix for the next job
       - name: Process choice of cloud(s) for matrix
         id: process_cloud_choice
         run: |
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             echo "clouds={ \"selected_clouds\" : [ \"aws\" ] }" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            JSON="{ \"selected_clouds\" : [ \"azure\" ] }"
-            echo "clouds=$JSON" >> $GITHUB_OUTPUT
+            echo "clouds={ \"selected_clouds\" : [ \"azure\" ] }" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            JSON="{ \"selected_clouds\" : [ \"gcp\" ] }"
-            echo "clouds=$JSON" >> $GITHUB_OUTPUT
+            echo "clouds={ \"selected_clouds\" : [ \"gcp\" ] }" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            JSON="{ \"selected_clouds\" : [ \"aws\", \"azure\", \"gcp\" ] }"
-            echo "clouds=$JSON" >> $GITHUB_OUTPUT
+            echo "clouds={ \"selected_clouds\" : [ \"aws\", \"azure\", \"gcp\" ] }" >> $GITHUB_OUTPUT
           fi
 
 
@@ -45,11 +42,11 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false # treat each job as separate
-      matrix:
+      matrix: # matrix comes from previous job
         cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds).selected_clouds }}
 
     steps:
-      - name: Set repo env
+      - name: Set cloud-specific repo env
         run: |
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_ENV

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Set repo env
         run: |
           echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+          echo "CLOUDS MATRIX.clouds: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -62,9 +62,7 @@ jobs:
             if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
           - modules.cloudid: gcp
             modules.repo: 'terraform-google-vmseries-modules'
-            if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
-        
-
+            # if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
 
     steps:
       # - name: Set repo variable based on cloud_id

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -31,7 +31,8 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            JSON="{ \"cloud_list\": [ \"aws\" ] }"
+            JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
+            JSON="{ [ \"aws\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
@@ -55,8 +56,8 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-    #   matrix:
-    #     cloudid: ${{ needs.generate-matrix.outputs.clouds }}
+      matrix:
+        cloudid: ${{ needs.generate-matrix.outputs.clouds }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -57,14 +57,13 @@ jobs:
       repo: ''
     strategy:
       fail-fast: false # treat each job as separate
-      # matrix:
-      #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
+      matrix:
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
 
     steps:
       - name: Set repo env
         run: |
           echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
-          echo "CLOUDS MATRIX.clouds: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,20 +27,31 @@ jobs:
         id: process_cloud_choice
         run: |
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-          case "${{ inputs.cloud-id }}" in
-            all)
-              echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
-              ;;
-            aws)
-              echo "clouds=['aws']" >> $GITHUB_ENV
-              ;;
-            azure)
-              echo "clouds=['azure']" >> $GITHUB_ENV
-              ;;
-            gcp)
-              echo "clouds=['gcp']" >> $GITHUB_ENV
-              ;;
-          esac    
+
+          if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
+            echo "clouds=['aws']" >> $GITHUB_ENV
+          elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
+            echo "clouds=['azure']" >> $GITHUB_ENV
+          elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
+            echo "clouds=['gcp']" >> $GITHUB_ENV
+          elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
+            echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
+          fi          
+
+        #   case "${{ inputs.cloud-id }}" in
+        #     all)
+        #       echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
+        #       ;;
+        #     aws)
+        #       echo "clouds=['aws']" >> $GITHUB_ENV
+        #       ;;
+        #     azure)
+        #       echo "clouds=['azure']" >> $GITHUB_ENV
+        #       ;;
+        #     gcp)
+        #       echo "clouds=['gcp']" >> $GITHUB_ENV
+        #       ;;
+        #   esac    
       - name: Show CLOUDS
         run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,70 +15,155 @@ on:
           - azure
           - gcp
 
+          #
+          # ORIGINAL MATRIX
+          #
+          # matrix:
+          #   modules:
+          #     - cloudid: aws
+          #       repo: 'terraform-aws-vmseries-modules'
+          #     - cloudid: azure
+          #       repo: 'terraform-azurerm-vmseries-modules'
+          #     - cloudid: gcp
+          #       repo: 'terraform-google-vmseries-modules'
+
+################ PLAN ##############
+#
+# CASE:
+#   aws - GH_OUT: cloud=aws, repo=aws
+#   azure - GH_OUT: cloud=aws, repo=aws
+#   gcp - GH_OUT: cloud=aws, repo=aws
+#   all -  - GH_OUT: cloud=aws, repo=aws, cloud=zure
+
+
+
+
 jobs:
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.set_modules.outputs.modules }}
+    steps:
+      - name: Set modules variable for matrix
+        id: set_modules
+        run: |
+          echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
+          case "${{ inputs.cloud-id }}" in
+            all)
+              echo "modules=[
+                { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
+                { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
+                { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' }
+              ]" >> $GITHUB_ENV
+            aws)
+              echo "modules=[
+                { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
+              ]" >> $GITHUB_ENV
+            azure)
+              echo "modules=[
+                { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
+              ]" >> $GITHUB_ENV
+            gcp)
+              echo "modules=[
+                { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' },
+              ]" >> $GITHUB_ENV
+
+
+      # - name: Set matrix based on cloud-id
+      #   id: matrix
+      #   run: |
+      #     echo "::set-output name=matrix::[{}]"
+      #     case "${{ github.event.inputs.cloud-id }}" in
+      #       aws)
+      #         echo "::set-output name=cloudid::aws"
+      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules'"
+      #         ;;
+      #       azure)
+      #         echo "::set-output name=cloudid::azure"
+      #         echo "::set-output name=repo::'terraform-azurerm-vmseries-modules'"
+      #         ;;
+      #       gcp)
+      #         echo "::set-output name=cloudid::gcp"
+      #         echo "::set-output name=repo::'terraform-google-vmseries-modules'"
+      #         ;;
+      #       all)
+      #         echo "::set-output name=cloudid::all"
+      #         echo "::set-output name=repo::'terraform-aws-vmseries-modules', 'terraform-azurerm-vmseries-modules', 'terraform-google-vmseries-modules'"
+      #         ;;
+      #     }
+
   # setup-matrix:
-  #   name: Generate matrix
+  #   name: Create matrix
   #   runs-on: ubuntu-latest
-  
+  #   steps:
+  #     - name: Create matrix variable
+  #       run: |
+  #         echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
+
+  #         if [[ "${{ inputs.cloud_id }}" == "aws" ]]; then
+  #           echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+  #         elif [[ "${{ inputs.cloud_id }}" == "gcp" ]]; then
+  #           echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+  #         elif [[ "${{ inputs.cloud_id }}" == "azure" ]]; then
+  #           echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+  #         elif [[ "${{ inputs.cloud_id }}" == "all" ]]; then
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #           echo "::set-output name=repo::azure-repo"
+  #         fi
+  #       # To use a $GITHU_OUTPUT var: env.var_name
+
+      # matrix:
+      #   include:
+      #     - modules.cloudid: aws
+      #       modules.repo: 'terraform-aws-vmseries-modules'
+      #       if: ${{ inputs.cloud-id == 'aws' || inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: azure
+      #       modules.repo: 'terraform-azurerm-vmseries-modules'
+      #       if: ${{ inputs.cloud-id == 'azure' || inputs.cloud-id == 'all' }}
+      #     - modules.cloudid: gcp
+      #       cloudid: gcp
+      #       modules.repo: 'terraform-google-vmseries-modules'
+      #       repo: 'terraform-google-vmseries-modules'
+      #       if: ${{ inputs.cloud-id == 'gcp' || inputs.cloud-id == 'all' }}
+
+
   generate-docs:
     # name: Generate ${{ matrix.modules.cloudid }} module docs
     name: Generate ${{ matrix.cloudid }} module docs
     runs-on: ubuntu-latest
+    needs: generate-matrix
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        include:
+        ${{ needs.generate-matrix.outputs.modules }}
 
-          # AWS
-          - inputs:
-              cloud-id: aws
-            cloudid: aws
-            repo: 'terraform-aws-vmseries-modules'
-          - inputs:
-              cloud-id: all
-            cloudid: aws
-            repo: 'terraform-aws-vmseries-modules'
-          # Azure
-          - inputs:
-              cloud-id: azure
-            cloudid: azure
-            repo: 'terraform-azurerm-vmseries-modules'
-          - inputs:
-              cloud-id: all
-            cloudid: azure
-            repo: 'terraform-azurerm-vmseries-modules'
-          # GCP
-          - inputs:
-              cloud-id: gcp
-            cloudid: gcp
-            repo: 'terraform-google-vmseries-modules'
-          - inputs:
-              cloud-id: all
-            cloudid: gcp
-            repo: 'terraform-google-vmseries-modules'
-
-
-          # # AWS
-          # - inputs.cloud-id: aws
-          #   cloudid: aws
-          #   repo: 'terraform-aws-vmseries-modules'
-          # - inputs.cloud-id: all
-          #   cloudid: aws
-          #   repo: 'terraform-aws-vmseries-modules'
-          # # Azure
-          # - inputs.cloud-id: azure
-          #   cloudid: azure
-          #   repo: 'terraform-azurerm-vmseries-modules'
-          # - inputs.cloud-id: all
-          #   cloudid: azure
-          #   repo: 'terraform-azurerm-vmseries-modules'
-          # # GCP
-          # - inputs.cloud-id: gcp
-          #   cloudid: gcp
-          #   repo: 'terraform-google-vmseries-modules'
-          # - inputs.cloud-id: all
-          #   cloudid: gcp
-          #   repo: 'terraform-google-vmseries-modules'
+        # include:
+        #   # AWS
+        #   - inputs.cloud-id: aws
+        #     cloudid: aws
+        #     repo: 'terraform-aws-vmseries-modules'
+        #   - inputs.cloud-id: all
+        #     cloudid: aws
+        #     repo: 'terraform-aws-vmseries-modules'
+        #   # Azure
+        #   - inputs.cloud-id: azure
+        #     cloudid: azure
+        #     repo: 'terraform-azurerm-vmseries-modules'
+        #   - inputs.cloud-id: all
+        #     cloudid: azure
+        #     repo: 'terraform-azurerm-vmseries-modules'
+        #   # GCP
+        #   - inputs.cloud-id: gcp
+        #     cloudid: gcp
+        #     repo: 'terraform-google-vmseries-modules'
+        #   - inputs.cloud-id: all
+        #     cloudid: gcp
+        #     repo: 'terraform-google-vmseries-modules'
 
 
       # matrix:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.modules.cloudid }}
-            path: output
+          path: output
       
   
   sync-to-pan-dev:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,21 +15,79 @@ on:
           - azure
           - gcp
 
-jobs:
+jobs:  
   generate-docs:
     name: Generate ${{ matrix.modules.cloudid }} module docs
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # treat each job as separate
+
+      # matrix:
+      #   modules:
+      #     - cloudid: aws
+      #       repo: 'terraform-aws-vmseries-modules'
+      #     - cloudid: azure
+      #       repo: 'terraform-azurerm-vmseries-modules'
+      #     - cloudid: gcp
+      #       repo: 'terraform-google-vmseries-modules'
+
+      # matrix:
+      #   modules:
+      #     - requested_cloud_id: ${{ github.event.inputs.cloudid }}
+      #       include:
+      #         - requested_cloud_id: aws
+      #           cloud_id: aws
+      #           repo: 'terraform-aws-vmseries-modules'
+      #         - requested_cloud_id: azure
+      #           cloud_id: azure
+      #           repo: 'terraform-azurerm-vmseries-modules'
+      #         - requested_cloud_id: gcp
+      #           cloud_id: gcp
+      #           repo: 'terraform-google-vmseries-modules'
+      #         - requested_cloud_id: all
+      #           - cloud_id: aws
+      #             repo: 'terraform-aws-vmseries-modules'
+      #           - cloud_id: azure
+      #             repo: 'terraform-azurerm-vmseries-modules'
+      #           - cloud_id: gcp
+      #             repo: 'terraform-google-vmseries-modules'
+
       matrix:
-        modules:
-          - cloudid: aws
-            repo: 'terraform-aws-vmseries-modules'
-          - cloudid: azure
-            repo: 'terraform-azurerm-vmseries-modules'
-          - cloudid: gcp
-            repo: 'terraform-google-vmseries-modules'
+        include:
+          - modules.cloudid: aws
+            modules.repo: 'terraform-aws-vmseries-modules'
+            if: ${{ github.event.inputs.cloud-id == 'aws' || github.event.inputs.cloud-id == 'all' }}
+          - modules.cloudid: azure
+            modules.repo: 'terraform-azurerm-vmseries-modules'
+            if: ${{ github.event.inputs.cloud-id == 'azure' || github.event.inputs.cloud-id == 'all' }}
+          - modules.cloudid: gcp
+            modules.repo: 'terraform-google-vmseries-modules'
+            if: ${{ github.event.inputs.cloud-id == 'gcp' || github.event.inputs.cloud-id == 'all' }}
+        
+
+
     steps:
+      # - name: Set repo variable based on cloud_id
+      #   run: |
+      #     if [[ "${{ matrix.cloud_id }}" == "aws" ]]; then
+      #       echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
+      #     elif [[ "${{ matrix.cloud_id }}" == "gcp" ]]; then
+      #       echo "repo=terraform-azurerm-vmseries-modules" >> $GITHUB_OUTPUT
+      #     elif [[ "${{ matrix.cloud_id }}" == "azure" ]]; then
+      #       echo "repo=terraform-google-vmseries-modules" >> $GITHUB_OUTPUT
+      #     elif [[ "${{ matrix.cloud_id }}" == "all" ]]; then
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #       echo "::set-output name=repo::azure-repo"
+      #     fi
+      #   # To use a $GITHU_OUTPUT var: env.var_name
+
+
+
+
       - name: Checkout module repo for ${{ matrix.modules.cloudid }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -32,7 +32,7 @@ jobs:
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
             JSON_OLD="{ \"cloud_list\": [ \"aws\" ] }"
-            JSON="{ [ \"aws\" ] }"
+            JSON="{\"include\": [ \"aws\" ] }"
             echo "JSON IS: $JSON"
             echo "clouds=$JSON" >> $GITHUB_OUTPUT
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -64,12 +64,18 @@ jobs:
       #   cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
 
     steps:
+
+      - name: Show CLOUDS 1
+        run: echo "CLOUDS MATRIX ${{ needs.generate-matrix.outputs.clouds }}"
+
+      - name: Show CLOUDS 2
+        run: echo "CLOUDS MATRIX ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
+
+      - name: Show CLOUDS 3
+        run: echo "CLOUDS MATRIX ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
+
       - name: Set repo env
         run: |
-          echo "CLOUDS MATRIX: ${{ needs.generate-matrix.outputs.clouds }}"
-          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}"
-          echo "CLOUDS MATRIX: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}"
-
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.cloudid }}" == "gcp" ]]; then

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -55,7 +55,8 @@ jobs:
               echo "JSON_ARRAY=$jsonArrayString" >> $GITHUB_ENV
               ;;
             aws)
-              echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              # echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" } ] }" >> $GITHUB_ENV
+              echo "JSON_ARRAY={ \"cloudid\": \"aws\", \"repo\": \"terraform-aws-vmseries-modules\" }" >> $GITHUB_ENV
               ;;
             azure)
               echo "JSON_ARRAY={ \"modules\": [ { \"cloudid\": \"azure\", \"repo\": \"terraform-azurerm-vmseries-modules\" } ] }" >> $GITHUB_ENV

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        ${{ needs.generate-matrix.outputs.modules }}
+        ${{ fromJSON(needs.generate-matrix.outputs.modules) }}
 
         # include:
         #   # AWS

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds.clouds) }}
 
     steps:
       - name: Set repo env

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,57 +49,20 @@ jobs:
         id: set_modules
         run: |
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
-            case "${{ inputs.cloud-id }}" in
+          case "${{ inputs.cloud-id }}" in
             all)
-              echo "modules=\"[
-                { \\\"cloudid\\\": \\\"aws\\\", \\\"repo\\\": \\\"terraform-aws-vmseries-modules\\\" },
-                { \\\"cloudid\\\": \\\"azure\\\", \\\"repo\\\": \\\"terraform-azurerm-vmseries-modules\\\" },
-                { \\\"cloudid\\\": \\\"gcp\\\", \\\"repo\\\": \\\"terraform-google-vmseries-modules\\\" }
-              ]\"" >> $GITHUB_ENV
+              echo "modules=[ { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' }, { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' }, { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' } ]" >> $GITHUB_ENV
               ;;
             aws)
-              echo "modules=\"[
-                { \\\"cloudid\\\": \\\"aws\\\", \\\"repo\\\": \\\"terraform-aws-vmseries-modules\\\" }
-              ]\"" >> $GITHUB_ENV
+              echo "modules=[ { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' } ]" >> $GITHUB_ENV
               ;;
             azure)
-              echo "modules=\"[
-                { \\\"cloudid\\\": \\\"azure\\\", \\\"repo\\\": \\\"terraform-azurerm-vmseries-modules\\\" }
-              ]\"" >> $GITHUB_ENV
+              echo "modules=[ { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' } ]" >> $GITHUB_ENV
               ;;
             gcp)
-              echo "modules=\"[
-                { \\\"cloudid\\\": \\\"gcp\\\", \\\"repo\\\": \\\"terraform-google-vmseries-modules\\\" }
-              ]\"" >> $GITHUB_ENV
+              echo "modules=[ { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' } ]" >> $GITHUB_ENV
               ;;
           esac
-
-
-
-          # case "${{ inputs.cloud-id }}" in
-          #   all)
-          #     echo "modules=[
-          #       { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
-          #       { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
-          #       { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' }
-          #     ]" >> $GITHUB_ENV
-          #     ;;
-          #   aws)
-          #     echo "modules=[
-          #       { 'cloudid': 'aws', 'repo': 'terraform-aws-vmseries-modules' },
-          #     ]" >> $GITHUB_ENV
-          #     ;;
-          #   azure)
-          #     echo "modules=[
-          #       { 'cloudid': 'azure', 'repo': 'terraform-azurerm-vmseries-modules' },
-          #     ]" >> $GITHUB_ENV
-          #     ;;
-          #   gcp)
-          #     echo "modules=[
-          #       { 'cloudid': 'gcp', 'repo': 'terraform-google-vmseries-modules' },
-          #     ]" >> $GITHUB_ENV
-          #     ;;
-          # esac
 
 
       # - name: Set matrix based on cloud-id

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -135,9 +135,8 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false # treat each job as separate
-      # HERE
-      # matrix:
-      #   ${{ fromJSON(needs.generate-matrix.outputs.modules) }}
+      matrix:
+        ${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}
 
 
 
@@ -214,9 +213,9 @@ jobs:
 
     steps:
       
-      - name: Show modules
-        run: |
-          echo "${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}"
+      # - name: Show modules
+      #   run: |
+      #     echo "${{ fromJSON(needs.generate-matrix.outputs.JSON_ARRAY) }}"
 
       - name: Show input cloud-id
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -31,19 +31,19 @@ jobs:
           echo "CLOUD ID INPUT: ${{ inputs.cloud-id }}"
 
           if [[ "${{ inputs.cloud-id }}" == "aws" ]]; then
-            echo "clouds=['aws']" >> $GITHUB_ENV
+            echo "clouds=('aws')" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "azure" ]]; then
-            echo "clouds=['azure']" >> $GITHUB_ENV
+            echo "clouds=('azure')" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "gcp" ]]; then
-            echo "clouds=['gcp']" >> $GITHUB_ENV
+            echo "clouds=('gcp')" >> $GITHUB_ENV
           elif [[ "${{ inputs.cloud-id }}" == "all" ]]; then
-            echo "clouds=['aws','azure','gcp']" >> $GITHUB_ENV
+            echo "clouds=('aws','azure','gcp')" >> $GITHUB_ENV
           fi
 
         #   echo "${{ env.clouds }}"
 
-    #   - name: Show CLOUDS
-    #     run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
+      - name: Show CLOUDS
+        run: echo "${{ steps.process_cloud_choice.outputs.clouds }}"
 
   generate-docs:
     name: Generate ${{ matrix.cloudid }} module docs
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Set repo env
         run: |
-          echo "CLOUDS MATRIX ${{ needs.generate-matrix.outputs.clouds }}" # echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
+          echo "CLOUDS MATRIX: ${{ needs.generate-matrix.outputs.clouds }}" # echo "MATRIX CLOUD ID: ${{ matrix.cloudid }}"
 
           if [[ "${{ matrix.cloudid }}" == "aws" ]]; then
               echo "repo=terraform-aws-vmseries-modules" >> $GITHUB_OUTPUT

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false # treat each job as separate
       matrix:
-        cloudid: ${{ needs.generate-matrix.outputs.clouds }}
+        cloudid: ${{ fromJSON(needs.generate-matrix.outputs.clouds) }}
 
     steps:
       - name: Set repo env


### PR DESCRIPTION
## Description
Gives the sync system a cloud-specific ability. Using the inputs to GitHub Actions, either:
- only a specific cloud is processed (aws, azure or gcp), which is likely how the production system will work
- all clouds are processed (all), which is likely for testing most of the time

## Motivation and Context
Per-cloud sync functionality is being added for the source repos to be able to execute a sync upon release on their side

## How Has This Been Tested?
Tested locally in fork repo

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.